### PR TITLE
Improve clarity of times on stop page with labels

### DIFF
--- a/src/pages/stop/StopPage.css
+++ b/src/pages/stop/StopPage.css
@@ -27,6 +27,7 @@
 .StopPage .TripStopTime .time {
     width: 30px;
     text-align: right;
+    margin: 0 5px;
 }
 
 .StopPage .TripStopTime .route {

--- a/src/pages/stop/StopPage.tsx
+++ b/src/pages/stop/StopPage.tsx
@@ -237,11 +237,11 @@ type TripStopTimeProps = {
 function TripStopTime(props: TripStopTimeProps) {
   let displayTime = "";
   if (props.time < 30) {
-    displayTime = "Arr"
+    displayTime = "Now"
   } else if (props.time < 60) {
-    displayTime = String.fromCharCode(189)
+    displayTime = "30s"
   } else {
-    displayTime = Math.floor(props.time / 60).toString()
+    displayTime = Math.floor(props.time / 60).toString() + "m"
   }
 
   return (

--- a/src/pages/stop/StopPage.tsx
+++ b/src/pages/stop/StopPage.tsx
@@ -239,7 +239,7 @@ function TripStopTime(props: TripStopTimeProps) {
   if (props.time < 30) {
     displayTime = "Now"
   } else if (props.time < 60) {
-    displayTime = "30s"
+    displayTime = "<1m"
   } else {
     displayTime = Math.floor(props.time / 60).toString() + "m"
   }


### PR DESCRIPTION
## Context
- as a first time user today, I thought it was unclear what the numbers meant next to train
- adding a label should improve accessibility/UX

## Changes
- add time unit labels: `m` for minute, `s` for seconds
- replace `1/2` character with `30s`
- replace `Arr` with `Now`

## Test plan
| before | after
| --- | ---
| ![image](https://user-images.githubusercontent.com/11168401/219936381-92715a17-afb9-4ae6-abf9-b03169e7d206.png) | ![image](https://user-images.githubusercontent.com/11168401/219936467-d5a2b1b9-ba4d-4c5e-b49b-f52df3046269.png) <img width="316" alt="image" src="https://user-images.githubusercontent.com/11168401/219936491-d1968a94-314d-454d-a78a-d53abed5020f.png">



