### PR TITLE
Make sorting favorite stops toggleable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 is an open-source web app for the NYC subway.
 It displays train times based on realtime data from the MTA.
 The app's philosophy is to be very simple and 100% user-centric.
-No cookes, no tracking, no ads, etc.
+No cookies, no tracking, no ads, etc.
 
 This repository hosts the UI code.
 The app uses [Transiter](https://www.github.com/jamespfennell/transiter) on the backend.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "prettier": "prettier . --write"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/elements/Switch.css
+++ b/src/elements/Switch.css
@@ -2,6 +2,7 @@
 .switch-container {
   display: flex;
   align-items: center;
+  margin-bottom: 12px;
 }
 
 .switch {

--- a/src/hooks/settings.ts
+++ b/src/hooks/settings.ts
@@ -3,6 +3,7 @@ import { useLocalStorage } from "./localstorage";
 export const useSettings = () => {
   const [settings, setSettings] = useLocalStorage("rtr.settings", {
     useSeconds: false,
+    alphabetizeFavoriteStops: true,
   });
 
   return {

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -5,34 +5,36 @@ import { ErrorMessage, LoadingPanel } from "../elements/BasicPage";
 import buildNumber from "../build";
 
 export default function AboutPage() {
-  return <div>
-    <h1>About</h1>
-    <p>
-      realtimerail.nyc is an{" "}
-      <a href="https://github.com/jamespfennell/realtimerail.nyc-react">
-        open source app
-      </a>{" "}
-      that uses the{" "}
-      <a href="https://github.com/jamespfennell/transiter">
-        backend software Transiter
-      </a>{" "}
-      to access NYC subway realtime data.
-    </p>
-    <p>
-      To report a problem with the app, please{" "}
-      <a href="https://github.com/jamespfennell/realtimerail.nyc/issues">
-        open an issue on the GitHub repository
-      </a>.{" "}
-      Thank you in advance!
-    </p>
-    <p>
-      Subway symbols are licensed from the{" "}
-      <a href="http://www.mta.info">MTA</a>. Other icons are from the
-      open-source <a href="https://iconoir.com">Iconoir</a> project.
-    </p>
-    <h2>Debugging</h2>
-    <DebuggingInformation />
-  </div>
+  return (
+    <div>
+      <h1>About</h1>
+      <p>
+        realtimerail.nyc is an{" "}
+        <a href="https://github.com/jamespfennell/realtimerail.nyc-react">
+          open source app
+        </a>{" "}
+        that uses the{" "}
+        <a href="https://github.com/jamespfennell/transiter">
+          backend software Transiter
+        </a>{" "}
+        to access NYC subway realtime data.
+      </p>
+      <p>
+        To report a problem with the app, please{" "}
+        <a href="https://github.com/jamespfennell/realtimerail.nyc/issues">
+          open an issue on the GitHub repository
+        </a>
+        . Thank you in advance!
+      </p>
+      <p>
+        Subway symbols are licensed from the{" "}
+        <a href="http://www.mta.info">MTA</a>. Other icons are from the
+        open-source <a href="https://iconoir.com">Iconoir</a> project.
+      </p>
+      <h2>Debugging</h2>
+      <DebuggingInformation />
+    </div>
+  );
 }
 
 function DebuggingInformation() {
@@ -101,7 +103,9 @@ function Body(props: BodyProps) {
   }
   return (
     <div>
-      <p className="Center">UI build: <BuildNumber /></p>
+      <p className="Center">
+        UI build: <BuildNumber />
+      </p>
       <p className="Center">
         Transiter version: {props.transiterData.transiter?.version}
       </p>
@@ -152,9 +156,9 @@ function Body(props: BodyProps) {
 
 function BuildNumber() {
   if (buildNumber === "unset") {
-    return <span>N/A</span>
+    return <span>N/A</span>;
   }
-  return <span>#{buildNumber}</span>
+  return <span>#{buildNumber}</span>;
 }
 
 function Dot(props: { className: string }) {

--- a/src/pages/FavoritesPage.tsx
+++ b/src/pages/FavoritesPage.tsx
@@ -6,6 +6,7 @@ import { stopServiceMapsURL } from "../api/api";
 import { ListStopsReply } from "../api/types";
 import { ErrorMessage, LoadingPanel } from "../elements/BasicPage";
 import ListOfStops from "../elements/ListOfStops";
+import { useSettings } from "../hooks/settings";
 
 export default function FavoritesPage() {
   const { getFavoriteStops } = useFavorites();
@@ -23,6 +24,7 @@ export default function FavoritesPage() {
 }
 
 function Body(props: { favoriteStops: string[] }) {
+  const { settings } = useSettings();
   const httpData = useHttpData(
     stopServiceMapsURL(props.favoriteStops),
     null,
@@ -35,10 +37,22 @@ function Body(props: { favoriteStops: string[] }) {
       </ErrorMessage>
     );
   }
+  let favoriteStopsData = httpData.response?.stops;
+  // TODO this corrects the backend returning a response ordered by stop id instead of the order the IDs are passed in
+  // possibly fix this in the backend
+  if (!settings.alphabetizeFavoriteStops) {
+    favoriteStopsData?.sort(
+      (a, b) =>
+        props.favoriteStops.indexOf(a.id) - props.favoriteStops.indexOf(b.id),
+    );
+  }
   return (
     <div>
       <LoadingPanel loaded={httpData.response !== null}>
-        <ListOfStops stops={httpData.response?.stops!} orderByName={true} />
+        <ListOfStops
+          stops={favoriteStopsData ?? []}
+          orderByName={settings.alphabetizeFavoriteStops}
+        />
       </LoadingPanel>
     </div>
   );

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -12,8 +12,19 @@ export default function SettingsPage() {
         onChange={(checked: boolean) => {
           setSettings((prev) => ({ ...prev, useSeconds: checked }));
         }}
-        id="settings"
+        id={"useSeconds"}
         label={"View arrival time in seconds"}
+      />
+      <Switch
+        checked={settings.alphabetizeFavoriteStops}
+        onChange={(checked: boolean) => {
+          setSettings((prev) => ({
+            ...prev,
+            alphabetizeFavoriteStops: checked,
+          }));
+        }}
+        id={"alphabetizeFavoriteStops"}
+        label={"Alphabetize the favorite stops list"}
       />
     </div>
   );


### PR DESCRIPTION
This adds a settings page option for alphabetizing favorite stops to address #44. If turned off, the stops will be listed in the order they were added.

When just using the order as it's returned from the backend, I noticed the stops weren't actually showing up in the order they were added, and instead by the stop ID. I suspect that's due to this line in transiter: https://github.com/jamespfennell/transiter/blob/35e5bb31f2626fd0607fb13f34df18160c72d925/db/queries/stop_queries.sql#L50

For now, I've worked around the issue by sorting the items in the response on the client side to recover the order the IDs were passed in. Maybe we could remove that line in the SQL as a better fix, but I'm not sure if that would have any other implications.