### PR TITLE
Add route icons to alert headers

### DIFF
--- a/src/pages/RoutePage.css
+++ b/src/pages/RoutePage.css
@@ -68,7 +68,7 @@
 NOTE: by using the margins, we need to make the effective height of the element less that 1em
 so that the line spacing is not affected.
  */
-.Alert .description .RouteLogo {
+.Alert .RouteLogo {
   width: 1.2em;
   height: 1.2em;
   margin-top: -0.15em;

--- a/src/pages/RoutePage.tsx
+++ b/src/pages/RoutePage.tsx
@@ -88,7 +88,9 @@ function Alerts(props: AlertsProps) {
     console.log(alert.id);
     alertElements.push(
       <div key={alert.id} className="Alert">
-        <div className="header">{parsedAlert.header}</div>
+        <div className="header">
+          {replaceRouteIdsWithImages(parsedAlert.header)}
+        </div>
         <div className="description">
           {replaceRouteIdsWithImages(parsedAlert.description)}
         </div>
@@ -183,7 +185,7 @@ class StatusPanel extends React.Component<StatusPanelProps> {
     return this.props.alerts.length > 0;
   };
 
-  toggleAlerts = (event: any) => {
+  toggleAlerts = (_event: any) => {
     if (!this.canToggleAlerts()) {
       return;
     }


### PR DESCRIPTION
Closes #47.

Tweaked the CSS so that the alert route logo styles apply not just to the description.

Before:
<img width="358" alt="Screenshot 2024-02-18 at 1 43 03 AM" src="https://github.com/jamespfennell/realtimerail.nyc/assets/20712582/8df0ab11-5845-4625-8c4c-fa591a21782c">
After:
<img width="358" alt="Screenshot 2024-02-18 at 1 42 47 AM" src="https://github.com/jamespfennell/realtimerail.nyc/assets/20712582/7b571e2e-3068-47b9-b608-541a38762cfa">
