### PR TITLE
Add default route colors

### DIFF
--- a/src/elements/routelogo/RouteLogo.tsx
+++ b/src/elements/routelogo/RouteLogo.tsx
@@ -25,7 +25,7 @@ import { ReactComponent as ImageForW } from "./images/w.svg";
 import { ReactComponent as ImageForZ } from "./images/z.svg";
 import { ReactComponent as ImageForAccesible } from "./images/acc.svg";
 
-let routeIdToImage = {
+const routeIdToImage = {
   "1": ImageFor1,
   "2": ImageFor2,
   "3": ImageFor3,
@@ -58,7 +58,47 @@ let routeIdToImage = {
   SI: ImageForSIR,
   W: ImageForW,
   Z: ImageForZ,
-  AD: ImageForAccesible,
+  AD: ImageForAccesible, // TODO change icon
+} as const;
+
+export type RouteId = keyof typeof routeIdToImage;
+
+// Define defaults for routes which do not have a color in routes.txt.
+// The only routes lacking colors are SIR, H, and FS, but this defines defaults for all routes.
+export const routeIdToDefaultColor: Record<RouteId, string> = {
+  "1": "ee342e",
+  "2": "ee342e",
+  "3": "ee342e",
+  "4": "00933b",
+  "5": "00933b",
+  "5X": "00933b",
+  "6": "00933b",
+  "6X": "00933b",
+  "7": "b933ae",
+  "7X": "b933ae",
+  A: "2852ad",
+  B: "ff6219",
+  C: "2852ad",
+  D: "ff6219",
+  E: "2852ad",
+  F: "ff6219",
+  FS: "808183",
+  FX: "ff6219",
+  G: "6dbe45",
+  GS: "808183",
+  H: "808183",
+  J: "996433",
+  L: "a7a9ac",
+  M: "ff6219",
+  N: "fccc0a",
+  Q: "fccc0a",
+  R: "fccc0a",
+  S: "808183",
+  SIR: "213990",
+  SI: "213990",
+  W: "fccc0a",
+  Z: "996433",
+  AD: "000000", // TODO change color
 };
 
 export type RouteLogoProps = {

--- a/src/pages/RoutePage.tsx
+++ b/src/pages/RoutePage.tsx
@@ -59,10 +59,7 @@ function Body(route: Route) {
       <ServiceMap
         stops={stops}
         color={
-          "#" +
-          (route.color === ""
-            ? routeIdToDefaultColor[route.id as RouteId]
-            : route.color)
+          "#" + (route.color || routeIdToDefaultColor[route.id as RouteId])
         }
         type="Route"
         showTimes={false}

--- a/src/pages/RoutePage.tsx
+++ b/src/pages/RoutePage.tsx
@@ -5,6 +5,8 @@ import "./RoutePage.css";
 
 import RouteLogo, {
   replaceRouteIdsWithImages,
+  RouteId,
+  routeIdToDefaultColor,
 } from "../elements/routelogo/RouteLogo";
 import parseAlert, { buildStatusFromAlerts } from "../elements/Alert";
 import ServiceMap from "../elements/servicemap/ServiceMap";
@@ -56,7 +58,12 @@ function Body(route: Route) {
       />
       <ServiceMap
         stops={stops}
-        color={"#" + route.color}
+        color={
+          "#" +
+          (route.color === ""
+            ? routeIdToDefaultColor[route.id as RouteId]
+            : route.color)
+        }
         type="Route"
         showTimes={false}
       />


### PR DESCRIPTION
Closes #50.

This adds default colors for all routes, to address missing route colors from routes.txt for SIR, Rockaways shuttle, and Franklin Av shuttle. The colors were taken from the SVG files for the icons. Maybe there's a better way to track these that isn't hardcoding?

Before:
<img width="354" alt="Screenshot 2024-02-18 at 12 06 14 PM" src="https://github.com/jamespfennell/realtimerail.nyc/assets/20712582/7da5383e-b51e-4423-bdf5-8a5c05f99593">

After:
<img width="354" alt="Screenshot 2024-02-18 at 6 07 36 PM" src="https://github.com/jamespfennell/realtimerail.nyc/assets/20712582/dee698ad-b78c-4025-a778-17fbc807fb3e">


