### PR TITLE
Make status bar transparent on iOS PWA

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
     <meta name="msapplication-TileColor" content="#da532c" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
Hello! I noticed that when I install this app as a PWA on iOS, the status bar color is white (default). With this PR, I change the status bar color to transparent, so that it shows the underlying green color. This change only affects iOS PWAs, since I'm setting the `apple-mobile-web-app-status-bar-style` meta tag.

| Before | After |
|--------|--------|
| ![IMG_9397](https://github.com/user-attachments/assets/d37ed19f-9f80-4d64-9b55-89fbd790bb4d) | ![IMG_9398](https://github.com/user-attachments/assets/79393312-0211-468a-8002-5b9e4bffa374) | 

